### PR TITLE
Fix for issue with overrides on DefaultVippsOrderProcessor

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -27,10 +27,11 @@ If you previously used async method calls inside of an overriding class, please 
 Due to some performance concerns we have made some adjustments to the default implementation of IVippsOrderProcessor which should resonate in any inheriting implementation.
 
 `[Obsolete] Task<ProcessOrderResponse> ProcessOrderDetails(DetailsResponse detailsResponse, string orderId, Guid contactId, string marketId, string cartName)`
-Is now considered Obsolete and will be removed in the future. Instead two different versions are to take its place.
+Is now considered Obsolete and will be removed in the future. Instead different alternatives are to take its place.
 
-`Task<ProcessOrderResponse> FetchAndProcessOrderDetails(string orderId, Guid contactId, string marketId, string cartName)`
-Encapsulates all loading of `IPurchaseOrder`, `ICart` and `IVippsUserDetails` to have more control over simultaneous execution. This method should be used by callback controllers.
+`Task<ProcessOrderResponse> FetchAndProcessOrderDetailsAsync(string orderId, Guid contactId, string marketId, string cartName)` and
+`ProcessOrderResponse FetchAndProcessOrderDetails(string orderId, Guid contactId, string marketId, string cartName)`
+Encapsulates all loading of `IPurchaseOrder`, `ICart` and `IVippsUserDetails` to have more control over simultaneous execution. These methods should be used by callback controllers.
 
 `Task<ProcessOrderResponse> ProcessOrderDetails(DetailsResponse detailsResponse, string orderId, ICart cart)`
 Reuses an already loaded cart and executes without the need for loading a purchase order. This method is used internally by the polling logic and is not suited for public exposure.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -21,6 +21,9 @@ Dependency reference to `IVippsService` has been removed from the constructor.
 This will result in a build error that can be resolved by removing the `IVippsService` parameter from any inheriting classes.
 
 ### IVippsOrderProcessor
+`Task<ProcessOrderResponse> CreatePurchaseOrder(ICart cart)` has a new signature `ProcessOrderResponse CreatePurchaseOrder(ICart cart)` and is executed synchronously. 
+If you previously used async method calls inside of an overriding class, please use `AsyncHelper.RunSync(() => ...)` included in the Vipps package to execute.
+
 Due to some performance concerns we have made some adjustments to the default implementation of IVippsOrderProcessor which should resonate in any inheriting implementation.
 
 `[Obsolete] Task<ProcessOrderResponse> ProcessOrderDetails(DetailsResponse detailsResponse, string orderId, Guid contactId, string marketId, string cartName)`

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,7 +4,7 @@
 For performance reasons the VippsOrderId field has been migrated to use a different data type. Existing Vipps installs will undergo a migration that happens during site startup.
 Make sure to _backup the commerce database_ before upgrading if any error or data loss should happen. Actions taken during this migration are logged on `DEBUG` level.
 
-## Affected tables
+### Affected tables
 The following tables are affected by the database migration, please ensure beforehand that no tables have constraints (like indexes) that prohibit altering the column `VippsOrderId`.
 
 ```

--- a/src/Vipps/Services/DefaultVippsOrderProcessor.cs
+++ b/src/Vipps/Services/DefaultVippsOrderProcessor.cs
@@ -68,12 +68,7 @@ namespace Vipps.Services
             return Task.FromResult(result);
         }
 
-        public virtual Task<ProcessOrderResponse> CreatePurchaseOrder(ICart cart)
-        {
-            return Task.FromResult(ConvertToPurchaseOrder(cart));
-        }
-
-        protected virtual ProcessOrderResponse ConvertToPurchaseOrder(ICart cart)
+        public virtual ProcessOrderResponse CreatePurchaseOrder(ICart cart)
         {
             ProcessOrderResponse result;
 
@@ -295,7 +290,7 @@ namespace Vipps.Services
             payment.Status = PaymentStatus.Processed.ToString();
             AddNote(cart, payment, orderId, paymentDetails);
 
-            var loadOrCreatePurchaseOrderResponse = ConvertToPurchaseOrder(cart);
+            var loadOrCreatePurchaseOrderResponse = CreatePurchaseOrder(cart);
             if (loadOrCreatePurchaseOrderResponse.PurchaseOrder != null)
             {
                 return loadOrCreatePurchaseOrderResponse;

--- a/src/Vipps/Services/IVippsOrderProcessor.cs
+++ b/src/Vipps/Services/IVippsOrderProcessor.cs
@@ -8,7 +8,7 @@ namespace Vipps.Services
 {
     public interface IVippsOrderProcessor
     {
-        Task<ProcessOrderResponse> CreatePurchaseOrder(ICart cart);
+        ProcessOrderResponse CreatePurchaseOrder(ICart cart);
 
         Task<ProcessOrderResponse> FetchAndProcessOrderDetails(string orderId, Guid contactId, string marketId, string cartName);
 

--- a/src/Vipps/Services/IVippsOrderProcessor.cs
+++ b/src/Vipps/Services/IVippsOrderProcessor.cs
@@ -10,7 +10,9 @@ namespace Vipps.Services
     {
         ProcessOrderResponse CreatePurchaseOrder(ICart cart);
 
-        Task<ProcessOrderResponse> FetchAndProcessOrderDetails(string orderId, Guid contactId, string marketId, string cartName);
+        Task<ProcessOrderResponse> FetchAndProcessOrderDetailsAsync(string orderId, Guid contactId, string marketId, string cartName);
+
+        ProcessOrderResponse FetchAndProcessOrderDetails(string orderId, Guid contactId, string marketId, string cartName);
 
         [Obsolete("Please use another overload. This has performance concerns and will be removed in an upcoming version.")]
         Task<ProcessOrderResponse> ProcessOrderDetails(DetailsResponse detailsResponse, string orderId, Guid contactId,

--- a/src/Vipps/Services/VippsAsyncPaymentService.cs
+++ b/src/Vipps/Services/VippsAsyncPaymentService.cs
@@ -15,7 +15,7 @@ namespace Vipps.Services
         
         public async Task<ProcessAuthorizationResponse> ProcessAuthorization(Guid contactId, string marketId, string cartName, string orderId)
         {
-            var result = await _vippsOrderProcessor.FetchAndProcessOrderDetails(orderId, contactId, marketId, cartName);
+            var result = await _vippsOrderProcessor.FetchAndProcessOrderDetailsAsync(orderId, contactId, marketId, cartName);
             if (result.PurchaseOrder != null)
             {
                 return new ProcessAuthorizationResponse(result)

--- a/src/Vipps/Services/VippsPaymentService.cs
+++ b/src/Vipps/Services/VippsPaymentService.cs
@@ -242,7 +242,7 @@ namespace Vipps.Services
             string cartName,
             string orderId)
         {
-            var result = AsyncHelper.RunSync(() => _vippsOrderCreator.FetchAndProcessOrderDetails(orderId, contactId, marketId, cartName));
+            var result = _vippsOrderCreator.FetchAndProcessOrderDetails(orderId, contactId, marketId, cartName);
             if (result.PurchaseOrder != null)
             {
                 return new ProcessAuthorizationResponse(result)


### PR DESCRIPTION
- Overriding classes would have logic on CreatePurchaseOrder whereas this logic had been adjusted on a deeper level.

Fix is simply to expose the change as breaking in IVippsOrderProcessor forcing implementations to conform.